### PR TITLE
[not tested] - attempt fix

### DIFF
--- a/awesometts/service/forvo.py
+++ b/awesometts/service/forvo.py
@@ -25,6 +25,10 @@ from .base import Service
 from .common import Trait
 import urllib
 import requests
+import urllib3
+import warnings
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 __all__ = ['Forvo']
 
@@ -857,4 +861,5 @@ class Forvo(Service):
                 error_message = f"Status code: {response.status_code} error: {error_text} text: [{text}] voice: {options['voice']} gender: {sex}"
                 self._logger.error(error_message)
                 raise ValueError(error_message)
-        
+
+warnings.resetwarnings()


### PR DESCRIPTION
I haven't been able to test this in a build of the addon, but when running a standalone python file, it removes warnings from the output.
I think this _might_ fix the issue, because the UI behaviour hints at some kind of error not being handled properly.

Before: 
![CleanShot 2024-08-10 at 14 17 52@2x](https://github.com/user-attachments/assets/4905e36a-f72e-4750-b8b2-7acd4c53363a)

After
![CleanShot 2024-08-10 at 14 19 31@2x](https://github.com/user-attachments/assets/2a5fbc69-f1ce-42fe-a0d8-d8da8dfa44dc)
